### PR TITLE
ci: bump helmchart versions when deps are updated

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,5 +8,6 @@
       "automerge": false,
       "updateTypes": ["major", "minor"]
     }
-  ]
+  ],
+  "bumpVersion": "patch"
 }


### PR DESCRIPTION
this was already active because it was part of the shared renovate config, but was now removed from there.