### PR TITLE
fix(immich): update db image version

### DIFF
--- a/charts/immich/values.yaml
+++ b/charts/immich/values.yaml
@@ -55,7 +55,7 @@ postgresql:
   enabled: true
   image:
     repository: tensorchord/pgvecto-rs
-    tag: pg14-v0.2.1
+    tag: pg14-v0.3.0
   global:
     postgresql:
       auth:

--- a/charts/immich/values.yaml
+++ b/charts/immich/values.yaml
@@ -55,7 +55,7 @@ postgresql:
   enabled: true
   image:
     repository: tensorchord/pgvecto-rs
-    tag: pg14-v0.2.0
+    tag: pg14-v0.2.1
   global:
     postgresql:
       auth:


### PR DESCRIPTION
update pgvecto.rs to v0.2.1

(v0.3.0 is available, but before doing that change I want to wait until immich itself also updated their repos to it. seems like support for v 0.3.0 is included already, though)

edit: just checked and support seems to be there. will update this PR