### PR TITLE
feat(immich): set default storage quota to 10GB

### DIFF
--- a/charts/immich/values.yaml
+++ b/charts/immich/values.yaml
@@ -43,7 +43,7 @@ immich:
         autoRegister: true
         buttonText: "Login with Authentik"
         clientId: "x93MIUTyE80epWJKx2ie5yIqqxR2ODPD6aV2vwIS"
-        defaultStorageQuota: 50
+        defaultStorageQuota: 10
         issuerUrl: "https://auth.cluster.diluz.io/application/o/immich/"
         timeout: 30000
       passwordLogin:


### PR DESCRIPTION
this makes it easier to invite people for onetime use to add content to shared albums etc without accidentally allowing them to fill the server with a lot of data