### PR TITLE
fix(longhorn): remove cleanup jobs

### DIFF
--- a/charts/longhorn/templates/backups.yaml
+++ b/charts/longhorn/templates/backups.yaml
@@ -50,49 +50,6 @@ spec:
   retain: 14
   parameters:
     volumeBackupPolicy: "disabled"
----
-# Delete artifacts that are more than what we want to retain
-apiVersion: longhorn.io/v1beta2
-kind: RecurringJob
-metadata:
-  name: daily-snapshot-delete
-  namespace: {{ .Release.Namespace }}
-spec:
-  task: "snapshot-delete"
-  cron: "0 20 * * *"
-  retain: 24
-  concurrency: 1
-  groups:
-    - default
----
-# Remove artifacts that are marked for deletion
-apiVersion: longhorn.io/v1beta2
-kind: RecurringJob
-metadata:
-  name: daily-snapshot-cleanup
-  namespace: {{ .Release.Namespace }}
-spec:
-  task: "snapshot-cleanup"
-  cron: "0 23 * * *"
-  retain: 0
-  concurrency: 1
-  groups:
-    - default
----
-# Weekly filesystem trim
-apiVersion: longhorn.io/v1beta2
-kind: RecurringJob
-metadata:
-  name: weekly-trim
-  namespace: {{ .Release.Namespace }}
-spec:
-  task: "filesystem-trim"
-  # Every Sunday at 3 AM
-  cron: "0 3 * * 0"
-  retain: 0
-  concurrency: 1
-  groups:
-    - default
 
 # Manager Restarts
 # Backups often error out when the previous one failed to connect to our flakey s3 and therefore kept some phantom locks. restarting the managers solves this issue, so we do it before creating backups


### PR DESCRIPTION
this is a temporary removal. once our backups are fully available on the external system again, let's bring these back. but since currently we're rebuilding backups, this is just too much load on the system